### PR TITLE
replace np.int to int as np.int is deprecated and throws an error

### DIFF
--- a/DocumentUnderstanding/VGT/object_detection/ditod/Wordnn_embedding.py
+++ b/DocumentUnderstanding/VGT/object_detection/ditod/Wordnn_embedding.py
@@ -77,7 +77,7 @@ class WordnnEmbedding(nn.Module):
                     per_id = per_input_ids[word_idx]
                     
                     bbox = per_input_bbox[word_idx] / stride
-                    w_start, h_start, w_end, h_end = bbox.round().astype(np.int).tolist()
+                    w_start, h_start, w_end, h_end = bbox.round().astype(int).tolist()
                             
                     if self.use_UNK_text:
                         chargrid_map[iter_b, h_start:h_end, w_start: w_end] = 100


### PR DESCRIPTION
This will fix `AttributeError: module 'numpy' has no attribute 'int'.`.

Got this error while doing inference on CPU.