### PR TITLE
remove extra argument passed to save_pkl_file function

### DIFF
--- a/DocumentUnderstanding/VGT/object_detection/create_grid_input.py
+++ b/DocumentUnderstanding/VGT/object_detection/create_grid_input.py
@@ -212,4 +212,4 @@ if __name__ == "__main__":
     for page in range(len(word_grid)):
 
         grid = create_grid_dict(tokenizer, word_grid[page])
-        save_pkl_file(grid, args.output, f"page_{page}", page, args.model)
+        save_pkl_file(grid, args.output, f"page_{page}", args.model)


### PR DESCRIPTION
`save_pkl_file` is throwing an exception in the main function because it only takes four arguments, however five are passed. Removing unnecessary `page` argument. 