### PR TITLE
converts image considering format provided

### DIFF
--- a/DocumentUnderstanding/VGT/object_detection/pdf2img.py
+++ b/DocumentUnderstanding/VGT/object_detection/pdf2img.py
@@ -34,6 +34,6 @@ if __name__ == "__main__":
     for i, image in enumerate(images):
         image.save(
             os.path.join(
-                args.output, f"page_{i}.png"))
+                args.output, f"page_{i}.{args.format}"))
 
     logging.info(f"PDF converted to images and saved at {args.output}")


### PR DESCRIPTION
Solves issue #150 . The pdf2img script previously accepted both jpg and png as output format arguments, but always converted to png regardless of the argument provided. This PR fixes issue by correctly converting the PDF to the specified format.